### PR TITLE
fix: Fix daily priming toggle to use correct endpoint

### DIFF
--- a/custom_components/free_sleep/api.py
+++ b/custom_components/free_sleep/api.py
@@ -161,10 +161,10 @@ class FreeSleepAPI:
 
     :param enabled: Whether to enable (True) or disable (False) daily priming.
     """
-    url = f'{self.host}{DEVICE_STATUS_ENDPOINT}'
+    url = f'{self.host}{SETTINGS_ENDPOINT}'
     log.debug(f'Setting daily priming to {enabled} on device at "{url}".')
 
-    json_data = {'settings': {'primePodDaily': {'enabled': enabled}}}
+    json_data = {'primePodDaily': {'enabled': enabled}}
 
     await self.post(url, json_data)
 


### PR DESCRIPTION
`primePodDaily` is a part of `/api/settings`, not `/api/deviceStatus`.