### PR TITLE
fix: Use side name when constructing side devices

### DIFF
--- a/custom_components/free_sleep/__init__.py
+++ b/custom_components/free_sleep/__init__.py
@@ -53,6 +53,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     name,
   )
 
+  await coordinator.async_config_entry_first_refresh()
   pod = Pod(hass, coordinator, entry, status['hubVersion'], entry.data['host'])
 
   hass.data.setdefault(DOMAIN, {})
@@ -61,7 +62,6 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     coordinator,
   )
 
-  await coordinator.async_config_entry_first_refresh()
   await hass.config_entries.async_forward_entry_setups(entry, PLATFORMS)
 
   return True

--- a/custom_components/free_sleep/pod.py
+++ b/custom_components/free_sleep/pod.py
@@ -159,7 +159,7 @@ class Side:
     self.pod = pod
     self.type = side
     self.id = f'{pod.id}_{side}'
-    self.name = f'{pod.model} {side.capitalize()}'
+    self.name = f'{pod.model} {coordinator.data["settings"][side]["name"]}'
 
   @property
   def device_info(self) -> dict:


### PR DESCRIPTION
This updates the logic for getting the device name. Rather than hardcoding "Left" and "Right," the name configured in the Free Sleep settings are now used.