### PR TITLE
perf: Remove unnecessary API call for initialisation

### DIFF
--- a/custom_components/free_sleep/__init__.py
+++ b/custom_components/free_sleep/__init__.py
@@ -43,18 +43,14 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
   :return: True if setup was successful.
   """
   api = FreeSleepAPI(entry.data['host'], async_get_clientsession(hass))
-  status = await api.fetch_device_status()
-  name = status['hubVersion']
-
   coordinator = FreeSleepCoordinator(
     hass,
     log,
     api,
-    name,
   )
 
   await coordinator.async_config_entry_first_refresh()
-  pod = Pod(hass, coordinator, entry, status['hubVersion'], entry.data['host'])
+  pod = Pod(hass, coordinator, entry, entry.data['host'])
 
   hass.data.setdefault(DOMAIN, {})
   hass.data[DOMAIN][entry.entry_id] = (

--- a/custom_components/free_sleep/coordinator.py
+++ b/custom_components/free_sleep/coordinator.py
@@ -40,7 +40,7 @@ class FreeSleepCoordinator(DataUpdateCoordinator[PodState]):
   """A class that coordinates data updates for a Free Sleep Pod device."""
 
   def __init__(
-    self, hass: HomeAssistant, log: Logger, api: FreeSleepAPI, name: str
+    self, hass: HomeAssistant, log: Logger, api: FreeSleepAPI
   ) -> None:
     """
     Initialize the Free Sleep Coordinator.
@@ -51,7 +51,7 @@ class FreeSleepCoordinator(DataUpdateCoordinator[PodState]):
     super().__init__(
       hass,
       log,
-      name=name,
+      name='Free Sleep Coordinator',
       update_method=self._async_update_data,
       update_interval=timedelta(seconds=30),
     )

--- a/custom_components/free_sleep/pod.py
+++ b/custom_components/free_sleep/pod.py
@@ -25,7 +25,6 @@ class Pod:
     hass: HomeAssistant,
     coordinator: DataUpdateCoordinator[PodState],
     entry: ConfigEntry,
-    name: str,
     host: str,
   ) -> None:
     """
@@ -34,16 +33,16 @@ class Pod:
     :param hass: The Home Assistant instance.
     :param coordinator: The data update coordinator for the pod.
     :param entry: The configuration entry.
-    :param name: The name of the Free Sleep Pod device. This should be fetched
-    from the device during setup.
     :param host: The host address of the Free Sleep Pod device.
     """
     self.hass = hass
     self.coordinator = coordinator
     self.api = FreeSleepAPI(host, async_get_clientsession(hass))
 
+    name = coordinator.data['status']['hubVersion']
+
     self.id = entry.entry_id
-    self.model: str = name
+    self.model = name
     self.host = host
     self.name = name
     self.sides = [


### PR DESCRIPTION
On init, `fetch_device_status` would be used to get the name of the Pod device, but instead the coordinator can be used, since it fetches the data on init anyway.