### PR TITLE
ci: Fix GitHub release config

### DIFF
--- a/.github/release.yaml
+++ b/.github/release.yaml
@@ -20,7 +20,7 @@ changelog:
 
     - title: "📝 Other Changes"
       labels:
-        - *
+        - "*"
 
   exclude:
     labels:


### PR DESCRIPTION
`*` is a special character in Yaml and needs to be quoted.