### PR TITLE
ci: Remove `no-commit-to-branch` hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,6 @@ repos:
       - id: check-merge-conflict
       - id: check-toml
       - id: end-of-file-fixer
-      - id: no-commit-to-branch
       - id: pretty-format-json
         args:
           - --autofix


### PR DESCRIPTION
This does not work on `main`.