### PR TITLE
feat: Add action to execute arbitrary command

### DIFF
--- a/custom_components/free_sleep/api.py
+++ b/custom_components/free_sleep/api.py
@@ -12,6 +12,7 @@ from aiohttp import ClientResponse, ClientSession
 
 from .constants import (
   DEVICE_STATUS_ENDPOINT,
+  EXECUTE_ENDPOINT,
   JOBS_ENDPOINT,
   SCHEDULES_ENDPOINT,
   SERVER_INFO_URL,
@@ -211,6 +212,19 @@ class FreeSleepAPI:
     )
 
     await self.post(url, json_data)
+
+  async def execute(self, json_data: dict[str, Any]) -> dict[str, Any]:
+    """
+    Execute a command on the Free Sleep device.
+
+    :param json_data: The JSON data representing the command to execute.
+    """
+    url = f'{self.host}{EXECUTE_ENDPOINT}'
+    log.debug(
+      f'Executing command on device at "{url}" with data "{json_data}".'
+    )
+
+    return await self.post(url, json_data)
 
   async def run_jobs(self, jobs: list[str]) -> None:
     """

--- a/custom_components/free_sleep/constants.py
+++ b/custom_components/free_sleep/constants.py
@@ -4,9 +4,11 @@ from typing import Final, Literal
 
 DOMAIN: Final = 'free_sleep'
 
+EXECUTE_SERVICE: Final = 'execute'
 SET_SCHEDULE_SERVICE: Final = 'set_schedule'
 
 DEVICE_STATUS_ENDPOINT: Final = '/api/deviceStatus'
+EXECUTE_ENDPOINT: Final = '/api/execute'
 JOBS_ENDPOINT: Final = '/api/jobs'
 SERVICES_ENDPOINT: Final = '/api/services'
 SETTINGS_ENDPOINT: Final = '/api/settings'

--- a/custom_components/free_sleep/pod.py
+++ b/custom_components/free_sleep/pod.py
@@ -65,6 +65,16 @@ class Pod:
       'model': self.model,
     }
 
+  async def execute_command(self, command: str, value: str) -> dict[str, Any]:
+    """
+    Execute a command on the Free Sleep Pod device.
+
+    :param command: The command to execute.
+    :param value: The value associated with the command.
+    """
+    json_data = {'command': command, 'arg': value}
+    return await self.api.execute(json_data)
+
   async def set_prime_daily(self, enabled: bool) -> None:
     """
     Enable or disable daily priming for the Free Sleep Pod device.

--- a/custom_components/free_sleep/services.yaml
+++ b/custom_components/free_sleep/services.yaml
@@ -1,3 +1,26 @@
+execute:
+  fields:
+    pod:
+      required: true
+      selector:
+        device:
+          integration: free_sleep
+          multiple: false
+          entity:
+            domain: update
+
+    command:
+      required: true
+      example: SET_TEMP
+      selector:
+        text: {}
+
+    value:
+      required: false
+      example: 75
+      selector:
+        text: {}
+
 set_schedule:
   fields:
     side:

--- a/custom_components/free_sleep/translations/en.json
+++ b/custom_components/free_sleep/translations/en.json
@@ -106,6 +106,24 @@
     }
   },
   "services": {
+    "execute": {
+      "name": "Execute command",
+      "description": "Executes a command on the Free Sleep device. Note that this is a low-level operation and should be used with caution.",
+      "fields": {
+        "command": {
+          "name": "Command",
+          "description": "The command to execute on the Free Sleep device."
+        },
+        "pod": {
+          "name": "Pod",
+          "description": "The pod to execute the command on."
+        },
+        "value": {
+          "name": "Value",
+          "description": "The value to send with the command, if applicable."
+        }
+      }
+    },
     "set_schedule": {
       "name": "Set schedule",
       "description": "Sets the temperature schedule for the Free Sleep device, for the specified days and times.",


### PR DESCRIPTION
This adds a `free_sleep.execute` action which can be used to execute arbitrary commands on the pod. A list of commands can be found [here](https://github.com/throwaway31265/free-sleep/blob/a040434cdd2c160a8188b4452446454bf9c81c0e/server/src/8sleep/deviceApi.ts#L6-L25).