### PR TITLE
chore: Add selector to set_schedule action

### DIFF
--- a/custom_components/free_sleep/services.yaml
+++ b/custom_components/free_sleep/services.yaml
@@ -66,3 +66,5 @@ set_schedule:
           duration: 1
           enabled: false
           alarmTemperature: 82
+      selector:
+        object: {}


### PR DESCRIPTION
This allows editing the YAML value in the UI mode for the action, rather than just in YAML mode.