### PR TITLE
feat: limit vitals fetch to the last 5 minutes

### DIFF
--- a/custom_components/free_sleep/api.py
+++ b/custom_components/free_sleep/api.py
@@ -7,6 +7,7 @@ status and settings, as well as updating device configurations.
 
 from asyncio import Lock
 from collections.abc import Mapping
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 from aiohttp import ClientResponse, ClientSession
@@ -139,7 +140,14 @@ class FreeSleepAPI:
     url = f'{self.host}{VITALS_SUMMARY_ENDPOINT}'
     log.debug(f'Fetching vitals for side "{side}" from device at "{url}".')
 
-    return await self.get(url, params={'side': side})
+    start_time = datetime.now(UTC) - timedelta(minutes=5)
+    return await self.get(
+      url,
+      params={
+        'side': side,
+        'startTime': start_time.strftime('%Y-%m-%dT%H:%M:%SZ'),
+      },
+    )
 
   async def fetch_presence(self) -> dict[str, Any]:
     """

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -6,6 +6,7 @@ mock responses for device status, settings, etc.
 """
 
 import logging
+import re
 from collections.abc import AsyncGenerator, Generator
 from typing import Any
 
@@ -336,12 +337,12 @@ async def integration(  # noqa: PLR0913
   http.get(url('/api/settings'), payload=mock_settings, repeat=True)
   http.get(url('/api/services'), payload=mock_services, repeat=True)
   http.get(
-    url('/api/metrics/vitals/summary?side=left'),
+    re.compile(r'.*/api/metrics/vitals/summary\?.*side=left.*'),
     payload=mock_vitals,
     repeat=True,
   )
   http.get(
-    url('/api/metrics/vitals/summary?side=right'),
+    re.compile(r'.*/api/metrics/vitals/summary\?.*side=right.*'),
     payload=mock_vitals,
     repeat=True,
   )

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,5 +1,6 @@
 """Tests for the API module."""
 
+from datetime import UTC, datetime, timedelta
 from typing import Any, cast
 from unittest.mock import patch
 
@@ -255,14 +256,27 @@ async def test_fetch_vitals(
   side: PodSide,
 ) -> None:
   """Test fetching device vitals."""
-  http.get(url(f'/api/metrics/vitals/summary?side={side}'), payload=mock_vitals)
+  frozen_now = datetime(2025, 1, 1, 12, 0, 0, tzinfo=UTC)
+  start_time = frozen_now - timedelta(minutes=5)
+  start_time_str = start_time.strftime('%Y-%m-%dT%H:%M:%SZ')
 
-  result = await api.fetch_vitals(side)
+  http.get(
+    url(f'/api/metrics/vitals/summary?side={side}&startTime={start_time_str}'),
+    payload=mock_vitals,
+  )
+
+  with patch(
+    'custom_components.free_sleep.api.datetime',
+    wraps=datetime,
+  ) as mock_datetime:
+    mock_datetime.now.return_value = frozen_now
+    result = await api.fetch_vitals(side)
+
   assert result == mock_vitals
   http.assert_called_with(
     url=url('/api/metrics/vitals/summary'),
     method='GET',
-    params={'side': side},
+    params={'side': side, 'startTime': start_time_str},
     timeout=10,
   )
 


### PR DESCRIPTION
Pass `startTime` (5 minutes before the current UTC time) to the `/api/metrics/vitals/summary` endpoint. Previously the endpoint was called with no time constraint, returning all historical vitals records. Scoping it to the last 5 minutes ensures only current readings are used for sensors.

Tests are updated to freeze `datetime.now` so the expected `startTime` is deterministic, and the integration fixture uses `re.compile` patterns to match the vitals URLs regardless of the dynamic timestamp.