### PR TITLE
feat: keep vitals visible for 5 minutes after presence is lost

### DIFF
--- a/custom_components/free_sleep/coordinator.py
+++ b/custom_components/free_sleep/coordinator.py
@@ -155,8 +155,7 @@ class FreeSleepCoordinator(DataUpdateCoordinator[PodState]):
     if since is None:
       return False
 
-    elapsed = (datetime.now(UTC) - since).total_seconds() / 60
-    return elapsed < grace_minutes
+    return datetime.now(UTC) - since < timedelta(minutes=grace_minutes)
 
 
 class FirmwareUpdateCoordinator(DataUpdateCoordinator[FirmwareState]):

--- a/custom_components/free_sleep/coordinator.py
+++ b/custom_components/free_sleep/coordinator.py
@@ -4,7 +4,7 @@ which is responsible for fetching and updating the device state periodically.
 """
 
 from asyncio import gather
-from datetime import timedelta
+from datetime import UTC, datetime, timedelta
 from logging import Logger
 from typing import Any, TypedDict
 
@@ -65,6 +65,7 @@ class FreeSleepCoordinator(DataUpdateCoordinator[PodState]):
     )
 
     self.api = api
+    self.presence_false_since: dict[PodSide, datetime] = {}
 
   async def _async_update_data(self) -> PodState:
     """
@@ -119,6 +120,12 @@ class FreeSleepCoordinator(DataUpdateCoordinator[PodState]):
       'right': presence.get('right', {}),
     }
 
+    for side in ('left', 'right'):
+      if presence_dict[side].get('present'):
+        self.presence_false_since.pop(side, None)
+      elif side not in self.presence_false_since:
+        self.presence_false_since[side] = datetime.now(UTC)
+
     return PodState(
       services=services,
       settings=settings,
@@ -126,6 +133,30 @@ class FreeSleepCoordinator(DataUpdateCoordinator[PodState]):
       vitals=vitals_dict,
       presence=presence_dict,
     )
+
+  def is_vitals_valid(self, side: PodSide, grace_minutes: int = 5) -> bool:
+    """
+    Return True if vitals should be displayed for the given side.
+
+    Stays True for up to `grace_minutes` after presence is lost, so brief
+    detection gaps don't immediately blank the sensors.
+
+    :param side: The side of the pod ("left" or "right").
+    :param grace_minutes: How long to keep showing vitals after presence is
+      lost.
+    """
+    if self.data is None:
+      return False
+
+    if self.data['presence'][side].get('present'):
+      return True
+
+    since = self.presence_false_since.get(side)
+    if since is None:
+      return False
+
+    elapsed = (datetime.now(UTC) - since).total_seconds() / 60
+    return elapsed < grace_minutes
 
 
 class FirmwareUpdateCoordinator(DataUpdateCoordinator[FirmwareState]):

--- a/custom_components/free_sleep/sensor.py
+++ b/custom_components/free_sleep/sensor.py
@@ -36,6 +36,7 @@ class FreeSleepSensorDescription(SensorEntityDescription):
 
   name: str
   state_class: SensorStateClass | None = None
+  requires_presence: bool = False
 
   get_value: Callable[[dict[str, Any]], StateType] | None = None
 
@@ -67,6 +68,7 @@ POD_SIDE_SENSORS: tuple[FreeSleepSensorDescription, ...] = (
     native_unit_of_measurement='bpm',
     state_class=SensorStateClass.MEASUREMENT,
     icon='mdi:heart-pulse',
+    requires_presence=True,
     get_value=lambda data: data['vitals']['avgHeartRate'],
   ),
   FreeSleepSensorDescription(
@@ -76,6 +78,7 @@ POD_SIDE_SENSORS: tuple[FreeSleepSensorDescription, ...] = (
     native_unit_of_measurement='breaths/min',
     state_class=SensorStateClass.MEASUREMENT,
     icon='mdi:lungs',
+    requires_presence=True,
     get_value=lambda data: data['vitals']['avgBreathingRate'],
   ),
   FreeSleepSensorDescription(
@@ -85,6 +88,7 @@ POD_SIDE_SENSORS: tuple[FreeSleepSensorDescription, ...] = (
     native_unit_of_measurement='ms',
     state_class=SensorStateClass.MEASUREMENT,
     icon='mdi:heart',
+    requires_presence=True,
     get_value=lambda data: data['vitals']['avgHRV'],
   ),
 )
@@ -226,6 +230,13 @@ class FreeSleepSideSensor(
     """
     if self.entity_description.get_value:
       data = self.side.get_side_data(self.coordinator.data)
+
+      if (
+        self.entity_description.requires_presence
+        and not self.coordinator.is_vitals_valid(self.side.type)
+      ):
+        return None
+
       return self.entity_description.get_value(data)
 
     return None

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,0 +1,80 @@
+"""Tests for the coordinator module."""
+
+import logging
+import re
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from aioresponses import aioresponses
+from homeassistant.core import HomeAssistant
+from pytest_homeassistant_custom_component.common import MockConfigEntry
+
+from custom_components.free_sleep.api import FreeSleepAPI
+from custom_components.free_sleep.constants import DOMAIN
+from custom_components.free_sleep.coordinator import FreeSleepCoordinator
+from tests.helpers import Url
+
+
+async def test_is_vitals_valid_no_data(
+  hass: HomeAssistant,
+  api: FreeSleepAPI,
+) -> None:
+  """is_vitals_valid returns False when the coordinator has no data yet."""
+  coordinator = FreeSleepCoordinator(hass, logging.getLogger(__name__), api)
+  assert coordinator.is_vitals_valid('left') is False
+
+
+async def test_is_vitals_valid_no_timer(
+  hass: HomeAssistant,
+  integration: MockConfigEntry,
+) -> None:
+  """is_vitals_valid returns False when presence is False with no timer set."""
+  _pod, coordinator = hass.data[DOMAIN][integration.entry_id]
+
+  coordinator.presence_false_since.clear()
+
+  assert coordinator.is_vitals_valid('left') is False
+  assert coordinator.is_vitals_valid('right') is False
+
+
+async def test_presence_false_since_cleared_on_refresh(  # noqa: PLR0913
+  hass: HomeAssistant,
+  api: FreeSleepAPI,
+  http: aioresponses,
+  url: Url,
+  mock_device_status: dict[str, Any],
+  mock_settings: dict[str, Any],
+  mock_services: dict[str, Any],
+  mock_vitals: dict[str, Any],
+) -> None:
+  """presence_false_since is cleared when presence becomes True on refresh."""
+  coordinator = FreeSleepCoordinator(hass, logging.getLogger(__name__), api)
+
+  coordinator.presence_false_since = {
+    'left': datetime.now(UTC) - timedelta(minutes=1),
+    'right': datetime.now(UTC) - timedelta(minutes=1),
+  }
+
+  http.get(url('/api/deviceStatus'), payload=mock_device_status)
+  http.get(url('/api/settings'), payload=mock_settings)
+  http.get(url('/api/services'), payload=mock_services)
+  http.get(
+    re.compile(r'.*/api/metrics/vitals/summary\?.*side=left.*'),
+    payload=mock_vitals,
+  )
+  http.get(
+    re.compile(r'.*/api/metrics/vitals/summary\?.*side=right.*'),
+    payload=mock_vitals,
+  )
+  http.get(
+    url('/api/metrics/presence'),
+    payload={
+      'left': {'present': True, 'lastUpdatedAt': '2025-12-18T14:00:00-06:00'},
+      'right': {'present': True, 'lastUpdatedAt': '2025-12-18T14:00:00-06:00'},
+    },
+  )
+
+  await coordinator.async_refresh()
+
+  assert 'left' not in coordinator.presence_false_since
+  assert 'right' not in coordinator.presence_false_since

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -1,9 +1,15 @@
 """Tests for the sensor platform."""
 
-from homeassistant.core import HomeAssistant
+from copy import deepcopy
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from homeassistant.core import HomeAssistant, State
 from homeassistant.helpers import entity_registry
 from pytest_homeassistant_custom_component.common import MockConfigEntry
 from syrupy import SnapshotAssertion
+
+from custom_components.free_sleep.constants import DOMAIN
 
 
 async def test_sensor_platform(
@@ -32,3 +38,79 @@ async def test_sensor_platform(
   )
 
   assert entries == snapshot
+
+
+VITALS_ENTITY_IDS = [
+  'sensor.pod_4_left_heart_rate',
+  'sensor.pod_4_left_respiration_rate',
+  'sensor.pod_4_left_hrv',
+  'sensor.pod_4_right_heart_rate',
+  'sensor.pod_4_right_respiration_rate',
+  'sensor.pod_4_right_hrv',
+]
+
+VITALS_EXPECTED_VALUES = [
+  ('sensor.pod_4_left_heart_rate', '50'),
+  ('sensor.pod_4_left_respiration_rate', '14'),
+  ('sensor.pod_4_left_hrv', '40'),
+  ('sensor.pod_4_right_heart_rate', '50'),
+  ('sensor.pod_4_right_respiration_rate', '14'),
+  ('sensor.pod_4_right_hrv', '40'),
+]
+
+
+@pytest.mark.usefixtures('integration')
+async def test_vitals_sensors_available_during_grace_window(
+  hass: HomeAssistant,
+) -> None:
+  """Vitals sensors still report values just after presence is lost."""
+  # The integration fixture starts with present=False, so _presence_false_since
+  # is set to "now" — we are inside the 5-minute grace window.
+  for entity_id, expected in VITALS_EXPECTED_VALUES:
+    sensor = hass.states.get(entity_id)
+    assert isinstance(sensor, State)
+    assert sensor.state == expected, (
+      f'{entity_id} should show {expected} within the grace window'
+    )
+
+
+async def test_vitals_sensors_unavailable_after_grace_window(
+  hass: HomeAssistant,
+  integration: MockConfigEntry,
+) -> None:
+  """Vitals sensors report unknown once the grace window has elapsed."""
+  _pod, coordinator = hass.data[DOMAIN][integration.entry_id]
+
+  expired = datetime.now(UTC) - timedelta(minutes=6)
+  coordinator.presence_false_since = {'left': expired, 'right': expired}
+
+  coordinator.async_set_updated_data(coordinator.data)
+  await hass.async_block_till_done()
+
+  for entity_id in VITALS_ENTITY_IDS:
+    sensor = hass.states.get(entity_id)
+    assert isinstance(sensor, State)
+    assert sensor.state == 'unknown', (
+      f'{entity_id} should be unknown after the grace window'
+    )
+
+
+async def test_vitals_sensors_available_when_present(
+  hass: HomeAssistant,
+  integration: MockConfigEntry,
+) -> None:
+  """Vitals sensors report values when someone is present in bed."""
+  _pod, coordinator = hass.data[DOMAIN][integration.entry_id]
+  new_data = deepcopy(coordinator.data)
+  new_data['presence']['left']['present'] = True
+  new_data['presence']['right']['present'] = True
+
+  coordinator.async_set_updated_data(new_data)
+  await hass.async_block_till_done()
+
+  for entity_id, expected in VITALS_EXPECTED_VALUES:
+    sensor = hass.states.get(entity_id)
+    assert isinstance(sensor, State)
+    assert sensor.state == expected, (
+      f'{entity_id} should be {expected} when present'
+    )

--- a/tests/test_sensor.py
+++ b/tests/test_sensor.py
@@ -64,7 +64,7 @@ async def test_vitals_sensors_available_during_grace_window(
   hass: HomeAssistant,
 ) -> None:
   """Vitals sensors still report values just after presence is lost."""
-  # The integration fixture starts with present=False, so _presence_false_since
+  # The integration fixture starts with present=False, so presence_false_since
   # is set to "now" — we are inside the 5-minute grace window.
   for entity_id, expected in VITALS_EXPECTED_VALUES:
     sensor = hass.states.get(entity_id)
@@ -74,7 +74,7 @@ async def test_vitals_sensors_available_during_grace_window(
     )
 
 
-async def test_vitals_sensors_unavailable_after_grace_window(
+async def test_vitals_sensors_unknown_after_grace_window(
   hass: HomeAssistant,
   integration: MockConfigEntry,
 ) -> None:


### PR DESCRIPTION
When presence transitions to `False`, vitals sensors now stay visible for a 5-minute grace window before going unavailable. This prevents brief detection gaps (the sensor momentarily losing signal) from immediately blanking the heart rate, respiration rate, and HRV sensors.

The grace window is tracked per side in `FreeSleepCoordinator.presence_false_since`. The timestamp is set the first time a side goes not-present and cleared when presence is restored.

Based on the implementation by @seanpasino in his fork of `hass-free-sleep`.